### PR TITLE
Modal dialogs for lexical entries, paradigms and cognates should have…

### DIFF
--- a/src/components/GroupingTagModal/index.js
+++ b/src/components/GroupingTagModal/index.js
@@ -358,7 +358,7 @@ class GroupingTagModal extends React.Component {
 
     return (
       <div>
-        <Modal dimmer open size="fullscreen">
+        <Modal dimmer open size="fullscreen" closeIcon onClose={this.props.closeModal}>
           <Modal.Header>Grouping tag</Modal.Header>
           <Modal.Content scrolling>
             <ModalContentWrapper>

--- a/src/components/LexicalEntryModal/index.js
+++ b/src/components/LexicalEntryModal/index.js
@@ -24,7 +24,7 @@ function LexicalEntryModal({
   const { id, translation, lexicalEntries } = node;
 
   return (
-    <Modal closeIcon size="fullscreen" open>
+    <Modal closeIcon size="fullscreen" open onClose={close}>
       <Modal.Header>{translation}</Modal.Header>
       <Modal.Content scrolling>
         <LexicalEntryViewByIds

--- a/src/components/LinkModal/index.js
+++ b/src/components/LinkModal/index.js
@@ -382,7 +382,7 @@ const LinkModal = (props) => {
   }
 
   return (
-    <Modal dimmer open size="fullscreen">
+    <Modal dimmer open size="fullscreen" closeIcon onClose={props.closeModal}>
       <Modal.Content>
         <Content {...props} />
       </Modal.Content>


### PR DESCRIPTION
… the close icon. Also it should be closed when pressing the 'Esc' button.